### PR TITLE
deploy to github page with action instead of netlify

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: Build and Deploy
+on: [push]
+permissions:
+  contents: write    
+  pages: write
+  id-token: write
+jobs:
+  build:    
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          npm install
+          npm run build
+
+      - name: Upload artifact 📦
+        id: artifact
+        uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
+        with:
+          path: build/
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,9 +3,10 @@ import react from '@vitejs/plugin-react-swc'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: 'ntu-lope-lab',
   plugins: [react()],
   build: {
-    outDir: 'build',
+    outDir: 'build',    
   },
 });
 


### PR DESCRIPTION
No javascript is touched. Only add a .github/workflow and update vite.config.json for `base` path.
Note that using this configuration will break the integration with netlify, which doesn't have a path component (ntu-lope-lab.netlify.app), while the github page link does (****.github.io/ntu-lope-lab).